### PR TITLE
Fixed stacking orbits & retained strength value

### DIFF
--- a/src/main/java/dev/plex/extras/TFMExtras.java
+++ b/src/main/java/dev/plex/extras/TFMExtras.java
@@ -95,6 +95,7 @@ public class TFMExtras extends PlexModule
 
         addDefaultMessage("playerOrbited", "<aqua>{0} - Orbiting {1}", "0 - The command sender, 1 - The person being orbited");
         addDefaultMessage("stoppedOrbiting", "<aqua>No longer orbiting {0}", "0 - The person no longer being orbited");
+        addDefaultMessage("alreadyOrbited", "<red>This player is already being orbited!");
         addDefaultMessage("emptyAdminInfo", "<red>The admin information section of the config.yml file has not been configured.");
         addDefaultMessage("cakeLyrics", "<rainbow>But there's no sense crying over every mistake. You just keep on trying till you run out of cake.");
         addDefaultMessage("areaEffectCloudClear", "<red>{0} - Removing all area effect clouds", "0 - The command sender");

--- a/src/main/java/dev/plex/extras/TFMExtras.java
+++ b/src/main/java/dev/plex/extras/TFMExtras.java
@@ -95,7 +95,7 @@ public class TFMExtras extends PlexModule
 
         addDefaultMessage("playerOrbited", "<aqua>{0} - Orbiting {1}", "0 - The command sender, 1 - The person being orbited");
         addDefaultMessage("stoppedOrbiting", "<aqua>No longer orbiting {0}", "0 - The person no longer being orbited");
-        addDefaultMessage("alreadyOrbited", "<red>This player is already being orbited!");
+        addDefaultMessage("alreadyOrbited", "<red>{0} is already being orbited!", "0 - The person that is already orbited");
         addDefaultMessage("emptyAdminInfo", "<red>The admin information section of the config.yml file has not been configured.");
         addDefaultMessage("cakeLyrics", "<rainbow>But there's no sense crying over every mistake. You just keep on trying till you run out of cake.");
         addDefaultMessage("areaEffectCloudClear", "<red>{0} - Removing all area effect clouds", "0 - The command sender");

--- a/src/main/java/dev/plex/extras/command/OrbitCommand.java
+++ b/src/main/java/dev/plex/extras/command/OrbitCommand.java
@@ -15,14 +15,15 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.UUID;
 
 @CommandParameters(name = "orbit", description = "Accelerates the player at a super fast rate", usage = "/<command> <target> [<<power> | stop>]")
 @CommandPermissions(permission = "plex.tfmextras.orbit")
 public class OrbitCommand extends PlexCommand
 {
-    private static final List<UUID> isOrbited = new ArrayList<>();
+    private static final Map<UUID, Integer> isOrbited = new HashMap<>();
 
     @Override
     protected Component execute(@NotNull CommandSender sender, @Nullable Player playerSender, String[] args)
@@ -54,6 +55,11 @@ public class OrbitCommand extends PlexCommand
             }
         }
 
+        if (isPlayerOrbited(targetPlayer.getUniqueId()))
+        {
+            return messageComponent("alreadyOrbited", targetPlayer.getName());
+        }
+
         startOrbiting(targetPlayer, strength);
         PlexUtils.broadcast(messageComponent("playerOrbited", sender.getName(), targetPlayer.getName()));
         return null;
@@ -77,7 +83,7 @@ public class OrbitCommand extends PlexCommand
     {
         player.setGameMode(org.bukkit.GameMode.SURVIVAL);
         player.addPotionEffect(new PotionEffect(PotionEffectType.LEVITATION, Integer.MAX_VALUE, strength, false, false));
-        isOrbited.add(player.getUniqueId());
+        isOrbited.put(player.getUniqueId(), strength);
     }
 
     private void stopOrbiting(Player player)
@@ -88,6 +94,11 @@ public class OrbitCommand extends PlexCommand
 
     public static boolean isPlayerOrbited(UUID playerId)
     {
-        return isOrbited.contains(playerId);
+        return isOrbited.containsKey(playerId);
+    }
+
+    public static Integer getOrbitStrength(UUID playerId)
+    {
+        return isOrbited.get(playerId);
     }
 }

--- a/src/main/java/dev/plex/extras/listener/OrbitEffectListener.java
+++ b/src/main/java/dev/plex/extras/listener/OrbitEffectListener.java
@@ -25,7 +25,8 @@ public class OrbitEffectListener extends PlexListener
                 {
                     if (OrbitCommand.isPlayerOrbited(player.getUniqueId()))
                     {
-                        player.addPotionEffect(new PotionEffect(PotionEffectType.LEVITATION, Integer.MAX_VALUE, 100, false, false));
+                        Integer strength = OrbitCommand.getOrbitStrength(player.getUniqueId());
+                        player.addPotionEffect(new PotionEffect(PotionEffectType.LEVITATION, Integer.MAX_VALUE, strength, false, false));
                     }
                 }, 2);
             }


### PR DESCRIPTION
The strength value was never retained for reassignment inside the event listener, this fixes that. I've also prevented the orbit from being stacked multiple times, only one entry per player.